### PR TITLE
Remove hardcoded /home path

### DIFF
--- a/.config/i3/i3blocks.conf
+++ b/.config/i3/i3blocks.conf
@@ -3,7 +3,7 @@ separator_block_width=15
 color=#E0E0E0
 
 [song]
-command=/home/nrouanet/.config/i3/scripts/spotify
+command=~/.config/i3/scripts/spotify
 label=
 interval=1
 color=#2ebd59
@@ -12,7 +12,7 @@ color=#2ebd59
 # pactl list sinks
 # /etc/pulse/default.pa: Add at the end:
 # set-card-profile 0 	output:analog-stereo
-command=/home/nrouanet/.config/i3/scripts/volume
+command=~/.config/i3/scripts/volume
 label=
 interval=1
 

--- a/.config/i3/scripts/volume
+++ b/.config/i3/scripts/volume
@@ -1,4 +1,4 @@
 #!/bin/bash
 sink=$(pactl list sinks | grep '^Sink #')
 
-/home/nrouanet/.config/i3/scripts/volume2 ${sink##*\#}
+~/.config/i3/scripts/volume2 ${sink##*\#}


### PR DESCRIPTION
This PR is to replace the 3 `/home/nrouanet` occurences with `~` in order to avoid bugs for other people :)